### PR TITLE
fix: upgrade hooks dependency for solve peering

### DIFF
--- a/packages/redux-data-model-hooks/package.json
+++ b/packages/redux-data-model-hooks/package.json
@@ -36,7 +36,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.6",
     "react-redux": "^7.1.0",
-    "redux-data-model": "^0.6.0",
+    "redux-data-model": "^0.13.0",
     "tslib": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## 📓  Overview
### 📔  Context (Issue)
- Dependency peering issues between `redux-data-model` and `redux-data-model-hooks` since `redux-data-model-hooks` requires lower version of `redux-data-model` and it causes of loss of usability.

### 🗒️  Guide
- Upgrade the version of `redux-data-model`  at  `redux-data-model-hooks` package so that we no longer consider the version and fix manually